### PR TITLE
Make topics expire locally in 6 years and fix local email log

### DIFF
--- a/local-dev/docker-compose.yml
+++ b/local-dev/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       MAILSERVICE_PASSWORD: c63d598dcf032c9f4f251fae99281c89
       EMAIL_SENDER: teemaderegister@tlu.ee
       EMAIL_SENDER_NAME: Teemaderegister
-      TOPICS_EXPIRE_IN_MONTHS: 12
+      TOPICS_EXPIRE_IN_MONTHS: 72
     command: 'run start-dev'
 
   tr-react:

--- a/local-dev/docker-compose.yml
+++ b/local-dev/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       LOGIN_ATTEMPT_BLOCK_DELAY_IN_MS: 3600000
       PORT: 3000
       NODE_ENV: development
-      LOG_LEVEL: 3
+      LOG_LEVEL: 4
       APP_NAME: teemaderegister
       SITE_URL: http://localhost:8080
       UPLOAD_DIR: ../data/uploads/

--- a/teemaderegister-be/src/utils/mail.js
+++ b/teemaderegister-be/src/utils/mail.js
@@ -5,6 +5,7 @@ const juice = require('juice')
 const Promise = require('bluebird')
 const path = require('path')
 const TEMPLATE_FOLDER_PATH = path.join(__dirname, '../', 'mailTemplates')
+const log = require('./logger')
 
 const transporterSettings = {
   host: process.env.MAILSERVICE_HOST,
@@ -43,6 +44,8 @@ module.exports.sendMail = (options) => {
     html,
     text
   }
+
+  log.debug(mailOptions)
 
   const nodemailerSendMail = Promise.promisify(transport.sendMail, { context: transport })
   return nodemailerSendMail(mailOptions)


### PR DESCRIPTION
Only affects local development.

Fixes expiry for accepted topics and logs email sent. 

![Screenshot 2020-12-09 at 08 45 47](https://user-images.githubusercontent.com/4492641/101594934-309b7100-39fb-11eb-91ad-7443707a61c4.png)

closes #26 